### PR TITLE
Use standard credential-finding logic

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -21,8 +21,6 @@ var NODE_RULE = {
 };
 
 var AWS_CONFIG = { 
-  accessKeyId: process.env.EC2_ACCESS_KEY, 
-  secretAccessKey: process.env.EC2_SECRET_KEY, 
   region: 'us-east-1' 
 };
 var TASK_QUEUE_URL = process.env.TASK_QUEUE_URL;  // set this in the environment to enable durability


### PR DESCRIPTION
From the node aws-sdk docs,
http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html

> Remember, if you set your AWS credentials in the shared credentials
> file or via environment variables, the AWS SDK for Node.js will
> automatically detect them, and you will not need to perform any manual
> credential configuration in your application.